### PR TITLE
add logic to prevent Magridd tile containing VIP card

### DIFF
--- a/Map.cpp
+++ b/Map.cpp
@@ -954,6 +954,9 @@ namespace Map {
 
         /* Goal 73 - Super Bracelet tile */
         GoalList[73].InsertElement(LAIR, NPC_QUEEN_MAGRIDD);
+        GoalList[73].InsertElement(LAIR, NPC_SOLDIER_WITH_LEO);
+        GoalList[73].InsertElement(LAIR, NPC_SOLDIER_DOK);
+        GoalList[73].InsertElement(LAIR, NPC_DR_LEO);
         GoalList[73].Target = 74;
 
         /* Goal 74 - Greenwood Leaf tile */


### PR DESCRIPTION
Description

The defined logic states that the only required check for the Soul Bracelet tile requires the Queen Magridd lair to have spawned, but this can cause the VIP card to spawn there. This causes a potential softlock as the VIP card is required to trigger the cutscene to make her disappear, making the tile accessible.
